### PR TITLE
Add support for using Docker secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ To install and run:
  | Variable name | Required? |
  |---|---|
  | `MQTT_HOST` | Yes |
- | `MQTT_USERNAME` | Yes |
- | `MQTT_PASSWORD` | Yes |
+ | `MQTT_USERNAME` | Yes, or `MQTT_USERNAME_FILE` |
+ | `MQTT_PASSWORD` | Yes, or `MQTT_PASSWORD_FILE` |
  | `DISCOVERY_PREFIX` | Yes |
  | `RTL_TOPIC` | Yes |
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,6 +13,7 @@ services:
       # Optionally use secret files
       # MQTT_USERNAME_FILE: /run/secrets/mqtt_username
       # MQTT_PASSWORD_FILE: /run/secrets/mqtt_password
+      # UNMASK_PASSWORD: "true" # Uncomment to disable password masking in log
       DISCOVERY_PREFIX: homeassistant
       RTL_TOPIC: "rtl_433/+/events"
 # Optional: Configure environment variables as docker secrets

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 services:
   rtl_433_ha_autodiscovery:
     build: .
@@ -10,5 +10,14 @@ services:
       MQTT_HOST: 127.0.0.1
       MQTT_USERNAME: yourUser
       MQTT_PASSWORD: yourPassword
+      # Optionally use secret files
+      # MQTT_USERNAME_FILE: /run/secrets/mqtt_username
+      # MQTT_PASSWORD_FILE: /run/secrets/mqtt_password
       DISCOVERY_PREFIX: homeassistant
       RTL_TOPIC: "rtl_433/+/events"
+# Optional: Configure environment variables as docker secrets
+# secrets:
+#   mqtt_username:
+#     environment: MQTT_USERNAME
+#   mqtt_password:
+#     environment: MQTT_PASSWORD

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,14 @@
 #!/bin/sh
 
+if [ -f ${MQTT_USERNAME_FILE:-'/run/secrets/mqtt_username'} ]; then
+  echo "MQTT_USERNAME_FILE Found. Setting MQTT_USERNAME from MQTT_USERNAME_FILE contents"
+  MQTT_USERNAME=$(cat ${MQTT_USERNAME_FILE:-'/run/secrets/mqtt_username'})
+fi
+if [ -f ${MQTT_PASSWORD_FILE:-'/run/secrets/mqtt_password'} ]; then
+  echo "MQTT_PASSWORD_FILE Found. Setting MQTT_PASSWORD from MQTT_PASSWORD_FILE contents"
+  MQTT_PASSWORD=$(cat ${MQTT_PASSWORD_FILE:-'/run/secrets/mqtt_password'})
+fi
+
 echo "Starting rtl_433_mqtt_hass.py..."
 echo "Running: python3 -u /rtl_433_mqtt_hass.py -d -u ${MQTT_USERNAME} -P ${MQTT_PASSWORD} -H ${MQTT_HOST} -D ${DISCOVERY_PREFIX} -R ${RTL_TOPIC}"
 python3 -u /rtl_433_mqtt_hass.py -d -u ${MQTT_USERNAME} -P ${MQTT_PASSWORD} -H ${MQTT_HOST} -D ${DISCOVERY_PREFIX} -R ${RTL_TOPIC}

--- a/run.sh
+++ b/run.sh
@@ -9,6 +9,9 @@ if [ -f ${MQTT_PASSWORD_FILE:-'/run/secrets/mqtt_password'} ]; then
   MQTT_PASSWORD=$(cat ${MQTT_PASSWORD_FILE:-'/run/secrets/mqtt_password'})
 fi
 
+MQTT_PASSWORD_MASK=$([ -n "$UNMASK_PASSWORD" ] && echo ${MQTT_PASSWORD} || printf '%s\n' "${MQTT_PASSWORD//?/*}")
+
 echo "Starting rtl_433_mqtt_hass.py..."
-echo "Running: python3 -u /rtl_433_mqtt_hass.py -d -u ${MQTT_USERNAME} -P ${MQTT_PASSWORD} -H ${MQTT_HOST} -D ${DISCOVERY_PREFIX} -R ${RTL_TOPIC}"
-python3 -u /rtl_433_mqtt_hass.py -d -u ${MQTT_USERNAME} -P ${MQTT_PASSWORD} -H ${MQTT_HOST} -D ${DISCOVERY_PREFIX} -R ${RTL_TOPIC}
+echo "Running: python3 -u /rtl_433_mqtt_hass.py ${DEBUG:+'-d'} -u ${MQTT_USERNAME} -P ${MQTT_PASSWORD_MASK} -H ${MQTT_HOST} -D ${DISCOVERY_PREFIX} -R ${RTL_TOPIC}"
+
+python3 -u /rtl_433_mqtt_hass.py ${DEBUG:+'-d'} -u ${MQTT_USERNAME} -P ${MQTT_PASSWORD} -H ${MQTT_HOST} -D ${DISCOVERY_PREFIX} -R ${RTL_TOPIC}


### PR DESCRIPTION
Optionally provide the MQTT credentials as Docker secrets. This requires an update to the run script to read the corresponding secret file contents into the local context's environment for the script.